### PR TITLE
Fix two bugs

### DIFF
--- a/lib/state_machines/yard/handlers.rb
+++ b/lib/state_machines/yard/handlers.rb
@@ -1,4 +1,4 @@
-module StateMachine
+module StateMachines
   module YARD
     # YARD custom handlers for integrating the state_machine DSL with the
     # YARD documentation system

--- a/lib/state_machines/yard/handlers/base.rb
+++ b/lib/state_machines/yard/handlers/base.rb
@@ -1,4 +1,4 @@
-module StateMachine
+module StateMachines
   module YARD
     module Handlers
       # Handles and processes nodes

--- a/lib/state_machines/yard/handlers/event.rb
+++ b/lib/state_machines/yard/handlers/event.rb
@@ -1,4 +1,4 @@
-module StateMachine
+module StateMachines
   module YARD
     module Handlers
       # Handles and processes #event

--- a/lib/state_machines/yard/handlers/machine.rb
+++ b/lib/state_machines/yard/handlers/machine.rb
@@ -1,4 +1,4 @@
-module StateMachine
+module StateMachines
   module YARD
     module Handlers
       # Handles and processes #state_machine

--- a/lib/state_machines/yard/handlers/state.rb
+++ b/lib/state_machines/yard/handlers/state.rb
@@ -1,4 +1,4 @@
-module StateMachine
+module StateMachines
   module YARD
     module Handlers
       # Handles and processes #state

--- a/lib/state_machines/yard/handlers/transition.rb
+++ b/lib/state_machines/yard/handlers/transition.rb
@@ -1,4 +1,4 @@
-module StateMachine
+module StateMachines
   module YARD
     module Handlers
       # Handles and processes #transition

--- a/lib/state_machines/yard/handlers/transition.rb
+++ b/lib/state_machines/yard/handlers/transition.rb
@@ -13,7 +13,7 @@ module StateMachines
             ast = statement.parameters.first
             ast.children.each do |assoc|
               # Skip conditionals
-              next if %w(if unless).include?(assoc[0].jump(:ident).source)
+              next if %w(if :if unless :unless).include?(assoc[0].jump(:ident).source)
 
               options[extract_requirement(assoc[0])] = extract_requirement(assoc[1])
             end


### PR DESCRIPTION
In order to make state_machines-yard work in my project (and everywhere, I'd say), I needed to introduce two patches as seen here:
https://github.com/openSUSE/travel-support-program/blob/master/lib/fix_state_machine_yard.rb

This pull request should fix both (with two separate commits): a inconsistent use of the new namespace StateMachines and a fragile handling of conditional transitions, like already explained here https://github.com/pluginaweek/state_machine/pull/283

With this modifications, I'm able to remove my monkey patching and the gem works like a charm for me. So it would be great if you can release an updated version.

Thanks.
