### PR TITLE
Qualify the namespace for Integrations

### DIFF
--- a/lib/state_machines/yard/handlers/machine.rb
+++ b/lib/state_machines/yard/handlers/machine.rb
@@ -117,7 +117,7 @@ module StateMachine
         # Gets the type of ORM integration being used based on the list of
         # ancestors (including mixins)
         def integration
-          @integration ||= Integrations.match_ancestors(namespace.inheritance_tree(true).map { |ancestor| ancestor.path })
+          @integration ||= StateMachines::Integrations.match_ancestors(namespace.inheritance_tree(true).map { |ancestor| ancestor.path })
         end
 
         # Gets the class type being used to define states.  Default is "Symbol".


### PR DESCRIPTION
To get this working, I had to:
- introduce a `--load` option to pre-load the code (perhaps this is ready to go into the README?)
- add this PR's `StateMachines::` namespacing of one line of code in the `machine` handler

---

``` shell
# .yardopts
--load load_yard_plugins.rb
lib/**/*.rb
app/**/*.rb -
```

``` ruby
# load_yard_plugins.rb
require 'state_machines'
require 'state_machines/graphviz'
require 'state_machines/yard'
```
