### PR TITLE
Rakefile: add a default task for Travis job

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,1 +1,6 @@
 require 'bundler/gem_tasks'
+
+desc 'No-op task to make Travis build run' 
+task :default do
+  # No-op
+end


### PR DESCRIPTION
In order to get Travis builds to finish, here is a `default` task.
