### PR TITLE
README: Brag about build status using badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Build Status](https://travis-ci.org/state-machines/state_machines-yard.svg?branch=master)](https://travis-ci.org/state-machines/state_machines-yard)
+
 # State Machines YARD plugin
 
 State machines YARD plugin for automated documentation


### PR DESCRIPTION
This PR adds an SVG badge of the Travis build status to the top of the README.
